### PR TITLE
-aオプションを実装しました

### DIFF
--- a/04.ls/my_ls
+++ b/04.ls/my_ls
@@ -1,13 +1,17 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'optparse'
+
 def main
+  params = ARGV.getopts('a')
+
   files = ARGV.select { |arg| File.file?(arg) }.sort
   directories = ARGV.empty? ? ['.'] : ARGV.select { |arg| File.directory?(arg) }.sort
   files_size = files.size
   directories_size = directories.size
   print_files(files, directories_size) unless files.empty?
-  print_directories(directories, directories_size, files_size)
+  print_directories(directories, directories_size, files_size, params)
 end
 
 def print_files(files, directories_size)
@@ -15,17 +19,18 @@ def print_files(files, directories_size)
   puts unless directories_size.zero?
 end
 
-def print_directories(directories, directories_size, files_size)
+def print_directories(directories, directories_size, files_size, params)
   directories.each_with_index do |directory, index|
     puts "#{directory}:" if directories_size > 1 || files_size.positive?
-    directory_entries = read_directory(directory)
+    directory_entries = read_directory(directory, params)
     print_list(directory_entries)
     puts if index < directories_size - 1
   end
 end
 
-def read_directory(directory)
-  Dir.glob('*', base: directory).sort
+def read_directory(directory, params)
+  flags = params['a'] ? File::FNM_DOTMATCH : 0
+  Dir.glob('*', flags, base: directory)
 end
 
 # 最大列数を指定し、行と列を入れ替えて表示する
@@ -36,7 +41,7 @@ def print_list(entries)
   slice_size = (entries.size / max_colmun).ceil
   sliced_entries = entries.each_slice(slice_size).map do |entry|
     max_width = calc_width(entry)
-    entry.map { |item| item.ljust(max_width + 2) }
+    multi_byte_ljust(entry, max_width + 2)
   end
   zipped_entries = sliced_entries[0].zip(*sliced_entries[1..])
   zipped_entries.each do |zipped_entry|
@@ -50,6 +55,14 @@ def calc_width(entry)
   entry.map do |entry_name|
     entry_name.each_char.map { |char| char.bytesize == 1 ? 1 : 2 }.sum
   end.max
+end
+
+def multi_byte_ljust(entry, max_width)
+  entry.map do |entry_name|
+    width = entry_name.each_char.map { |char| char.bytesize == 1 ? 1 : 2 }.sum
+    padding = max_width - width
+    entry_name + ' ' * padding
+  end
 end
 
 main


### PR DESCRIPTION
-aオプションの実装と`ljust`だと全角文字の表示がズレてしまっていたため、`multi_byte_ljust`を定義しました。